### PR TITLE
`dscales`, `dbounds`, `dx0` + plotting + fixed `pvoigt` fitting

### DIFF
--- a/spectrally/_class01_SpectralModel.py
+++ b/spectrally/_class01_SpectralModel.py
@@ -199,7 +199,7 @@ class SpectralModel(Previous):
 
     def get_spectral_model_moments(
         self,
-        key_model=None,
+        key=None,
         key_data=None,
         lamb=None,
     ):
@@ -216,7 +216,7 @@ class SpectralModel(Previous):
         Parameters
         ----------
         key_model : str
-            key to the desired spectral model
+            key to the desired spectral model (or spectral fit)
         key_data : str
             key to the data to be used as input for the model's free variables
         lamb:str or 1d np.ndarray, optional
@@ -231,7 +231,7 @@ class SpectralModel(Previous):
 
         dout = _moments.main(
             coll=self,
-            key_model=key_model,
+            key=key,
             key_data=key_data,
             lamb=lamb,
         )

--- a/spectrally/_class01_check_constraints.py
+++ b/spectrally/_class01_check_constraints.py
@@ -50,7 +50,16 @@ def _dconstraints(
 
     # add ref_nx (number of free parameters)
     knfree = f"nx_{key}"
-    coll.add_ref(knfree, size=len(dconstraints['groups']))
+    if knfree not in coll.dref.keys():
+        coll.add_ref(knfree, size=len(dconstraints['groups']))
+    elif coll.dref[knfree]['size'] != len(dconstraints['groups']):
+        msg = (
+            f"add_model('{key}') requires adding ref knfree = '{knfree}'"
+            " but it already exists and doesn't have the correct value!\n"
+            f"\t- existing: {coll.dref[knfree]['size']}\n"
+            f"\t- requested: {len(dconstraints['groups'])}\n"
+        )
+        raise Exception(msg)
 
     # dconstraints
     wsm = coll._which_model

--- a/spectrally/_class01_check_model.py
+++ b/spectrally/_class01_check_model.py
@@ -54,7 +54,16 @@ def _dmodel(
 
     # add ref_nfun
     knfunc = f"nf_{key}"
-    coll.add_ref(knfunc, size=len(dmodel))
+    if knfunc not in coll.dref.keys():
+        coll.add_ref(knfunc, size=len(dmodel))
+    elif coll.dref[knfunc]['size'] != len(dmodel):
+        msg = (
+            f"add_model('{key}') requires adding ref knfunc = '{knfunc}'"
+            " but it already exists and doesn't have the correct value!\n"
+            f"\t- existing: {coll.dref[knfunc]['size']}\n"
+            f"\t- requested: {len(dmodel)}\n"
+        )
+        raise Exception(msg)
 
     # dmodel
     dobj = {

--- a/spectrally/_class01_fit_func_1d.py
+++ b/spectrally/_class01_fit_func_1d.py
@@ -664,7 +664,7 @@ def _get_func_jacob(
             vind = dind['jac'][kfunc].get('gam')
             if vind is not None:
                 ival, ivar = vind['val'], vind['var']
-                dg_fl = 2 * scales[ival]
+                dg_fl = 2
                 dg_ftot = (1/5) * ftot_norm**(-4./5.) * dg_fl * (
                     2.69269*fg**4 + 2.42843*fg**3*2*fl
                     + 4.47163*fg**2*3*fl**2 + 0.07842*fg*4*fl**3 + 5*fl**4

--- a/spectrally/_class01_moments.py
+++ b/spectrally/_class01_moments.py
@@ -313,7 +313,7 @@ def _get_func_moments(
 
             # argmax
             dout[kfunc]['argmax'] = _get_line_argmax(
-                vccos, param_val, dind, kfunc, shape, axis,
+                vccos, param_val, dind, kfunc, amp.shape, axis,
             )
 
             # integral
@@ -342,7 +342,7 @@ def _get_func_moments(
 
             # argmax
             dout[kfunc]['argmax'] = _get_line_argmax(
-                vccos, param_val, dind, kfunc, shape, axis,
+                vccos, param_val, dind, kfunc, amp.shape, axis,
             )
 
             # integral
@@ -360,7 +360,7 @@ def _get_func_moments(
 
             # argmax
             dout[kfunc]['argmax'] = _get_line_argmax(
-                vccos, param_val, dind, kfunc, shape, axis,
+                vccos, param_val, dind, kfunc, amp.shape, axis,
             )
 
             # integral
@@ -389,7 +389,7 @@ def _get_func_moments(
 
             # argmax
             dout[kfunc]['argmax'] = _get_line_argmax(
-                vccos, param_val, dind, kfunc, shape, axis,
+                vccos, param_val, dind, kfunc, amp.shape, axis,
             )
 
             # integral

--- a/spectrally/_class02_compute_fit.py
+++ b/spectrally/_class02_compute_fit.py
@@ -148,11 +148,11 @@ def main(
         # binning
         binning=binning,
         # options
-        chain=None,
-        dscales=None,
-        dbounds_low=None,
-        dbounds_up=None,
-        dx0=None,
+        chain=chain,
+        dscales=dscales,
+        dbounds_low=dbounds_low,
+        dbounds_up=dbounds_up,
+        dx0=dx0,
         # solver options
         solver=solver,
         dsolver_options=dsolver_options,

--- a/spectrally/_class02_compute_fit.py
+++ b/spectrally/_class02_compute_fit.py
@@ -203,6 +203,8 @@ def main(
             verb=verb,
         )
 
+        dout = None
+
     return dout
 
 

--- a/spectrally/_class02_plot_fit.py
+++ b/spectrally/_class02_plot_fit.py
@@ -422,11 +422,15 @@ def _plot_2d(
 
     if details is True:
 
+        reflamb = coll2.ddata[dkeys['lamb']]['ref'][0]
         lamb = coll2.ddata[dkeys['lamb']]['data']
         nmax = dgroup0['X']['nmax']
         wsm = coll._which_model
         lfunc = coll.dobj[wsm][key_model]['keys']
-        refs = (coll2.ddata[dkeys['sum']]['ref'][0],)
+
+        refs = coll2.ddata[dkeys['sum']]['ref']
+        axis = refs.index(reflamb)
+        refs = (refs[axis - 1],)
         nan = np.full(lamb.shape, np.nan)
 
         kax = 'spectrum'

--- a/spectrally/_class02_x0_scale_bounds.py
+++ b/spectrally/_class02_x0_scale_bounds.py
@@ -9,6 +9,9 @@ Created on Sat Jul  6 17:31:49 2024
 import numpy as np
 
 
+from . import _class01_model_dict
+
+
 #############################################
 #############################################
 #    DEFAULTS
@@ -96,7 +99,16 @@ def _get_dict(
     for k0, v0 in din.items():
 
         # get func name and type + variable name
-        ftype = [k1 for k1, v1 in dmodel.items() if k0 in v1.keys()][0]
+        ftype = dmodel['_'.join(k0.split('_')[:-1])]['type']
+        if not ftype in _class01_model_dict._DMODEL.keys():
+            msg = (
+                "Unknown function type for variable:\n"
+                f"\t- var: {k0}\n"
+                f"\t- ftype: {ftype}\n"
+            )
+            raise Exception(msg)
+
+
         var = k0.split('_')[-1]
 
         if ftype not in dout.keys():
@@ -112,13 +124,13 @@ def _get_dict(
     # sort
     # --------------
 
-    lktypes = list(dout.items())
+    lktypes = list(dout.keys())
     for k0 in lktypes:
         lkvar = list(dout[k0].keys())
         for k1 in lkvar:
             inds = np.argsort(dout[k0][k1]['ind'])
-            dout[k0][var]['ind'] = np.array(dout[k0][k1]['ind'])[inds]
-            dout[k0][var]['val'] = np.array(dout[k0][k1]['val'])[inds]
+            dout[k0][k1]['ind'] = np.array(dout[k0][k1]['ind'])[inds]
+            dout[k0][k1]['val'] = np.array(dout[k0][k1]['val'])[inds]
 
     return dout
 

--- a/spectrally/tests/_spectralfit_input.py
+++ b/spectrally/tests/_spectralfit_input.py
@@ -896,7 +896,11 @@ def get_spectral_model_moments(coll=None):
 
     wsm = coll._which_model
     for kmodel in coll.dobj[wsm].keys():
-        _ = coll.get_spectral_model_moments(kmodel, key_data=f"xfree_{kmodel}")
+        _ = coll.get_spectral_model_moments(
+            kmodel,
+            key_data=f"xfree_{kmodel}",
+            lamb='lamb',
+        )
 
     return
 

--- a/spectrally/tests/_spectralfit_input.py
+++ b/spectrally/tests/_spectralfit_input.py
@@ -213,7 +213,7 @@ def add_data(coll=None, lamb=_LAMB, lamb0=_LAMB0):
 
     coll.add_data(
         key='data_pvoigt2',
-        data=np.random.poisson(pvoigt + 0.5* pvoigt2),
+        data=np.random.poisson(pvoigt + 0.5 * pvoigt2),
         ref='nlamb',
         units='counts',
     )
@@ -1166,7 +1166,7 @@ def compute_fit_double(coll=None, binning=None):
     # add fits if needed
     # ---------------
 
-    add_fit_single(coll)
+    add_fit_double(coll)
 
     # --------------------
     # compute

--- a/spectrally/tests/test_03_SpectralModel.py
+++ b/spectrally/tests/test_03_SpectralModel.py
@@ -99,5 +99,8 @@ class Test00_Populate():
     def test04_interpolate_spectral_model(self):
         _inputs.interpolate_spectral_model(self.coll)
 
-    def test05_plot_spectral_model(self):
+    def test05_get_spectral_model_moments(self):
+        _inputs.get_spectral_model_moments(self.coll)
+
+    def test06_plot_spectral_model(self):
         _inputs.plot_spectral_model(self.coll)

--- a/spectrally/tests/test_03_SpectralModel.py
+++ b/spectrally/tests/test_03_SpectralModel.py
@@ -65,6 +65,7 @@ class Test00_Populate():
 
         # add data
         _inputs.add_data(self.coll)
+        _inputs.add_xfree(self.coll)
 
         # add spectral lines
         pfe_json = os.path.join(_PATH_INPUT, 'spectrallines.json')

--- a/spectrally/tests/test_04_SpectralFit.py
+++ b/spectrally/tests/test_04_SpectralFit.py
@@ -101,8 +101,8 @@ class Test00_Populate():
         _inputs.compute_fit_double(self.coll)
 
     # def test07_compute_spectral_fit_1d_single_binning(self):
-        # # compute 1d
-        # _inputs.compute_fit_single(self.coll, binning=10)
+    #     # compute 1d
+    #     _inputs.compute_fit_single(self.coll, binning=10)
 
     def test08_compute_spectral_fit_1d_multi(self):
         # compute 1d


### PR DESCRIPTION
Main changes:
----------------

* `dscales`, `dbounds_low`, `dbounds_up` and `dx0` are now properly handled, as well as `chain`

* `get_spectral_model_moments(key=...)`:
    -  can handle both spectral models and spectral fits
    - is better coded (more generic)
    - is unit-tested
    
* `plot_spectral_fit(details=True)` fixed for 2d plots, but was due to cases with wrong ref selected

* `compute_spectral_fit()` debugged for `pvoigt`: scale of `gam` was accounted for twice in jacobian

Issues:
-------

Fixes, in devel:
* #17
* #18 
* #19  


Examples:
-----------

From unit tests on SpectralFit, before fix:

![image](https://github.com/user-attachments/assets/edadba39-d7fb-411b-a83c-9172a31ad2dc)


After fix:

![image](https://github.com/user-attachments/assets/3f46c710-4d65-4692-8d9e-63a5b733a692)


