### PR TITLE
Issue045 better moments

### DIFF
--- a/spectrally/_class01_SpectralModel.py
+++ b/spectrally/_class01_SpectralModel.py
@@ -202,6 +202,7 @@ class SpectralModel(Previous):
         key=None,
         key_data=None,
         lamb=None,
+        returnas=None,
     ):
         """
 
@@ -221,6 +222,10 @@ class SpectralModel(Previous):
             key to the data to be used as input for the model's free variables
         lamb:str or 1d np.ndarray, optional
             wavelenth vector to be used for computing limited integrals
+        returnas: str
+            Flag indicating whether to return dout as:
+                - 'dict_arrays': nested dict of {'ktype': {'kvar': array}}
+                - 'dict_varnames': dict of {'kfunc_var': values}
 
         Returns
         -------
@@ -234,6 +239,7 @@ class SpectralModel(Previous):
             key=key,
             key_data=key_data,
             lamb=lamb,
+            returnas=returnas,
         )
 
         return dout

--- a/spectrally/_class01_moments.py
+++ b/spectrally/_class01_moments.py
@@ -199,12 +199,12 @@ def _check_mz(
     # add mz if user-provided
     if dmz is not None:
 
-        for kfunc in ['gauss', 'pvoigt', 'voigt']:
+        for ktype in ['gauss', 'pvoigt', 'voigt']:
 
-            if dind.get(kfunc) is None:
+            if dind.get(ktype) is None:
                 continue
 
-            dind[kfunc]['mz']
+            dind[ktype]['mz']
 
     return dind
 
@@ -298,51 +298,51 @@ def _get_func_moments(
         # ---------------------
         # extract all variables
 
-        for kfunc, v0 in _model_dict._DMODEL.items():
-            if dind.get(kfunc) is not None:
+        for ktype, v0 in _model_dict._DMODEL.items():
+            if dind.get(ktype) is not None:
                 for kvar in v0['var']:
-                    dout[kfunc][kvar] = extract(kfunc, kvar, x_full)
+                    dout[ktype][kvar] = extract(ktype, kvar, x_full)
                     if x_std is not None:
-                        dout[kfunc][f"{kvar}_std"] = extract(kfunc, kvar, x_std)
+                        dout[ktype][f"{kvar}_std"] = extract(ktype, kvar, x_std)
 
         # ------------------
         # sum all poly
 
-        kfunc = 'poly'
-        if dind.get(kfunc) is not None:
+        ktype = 'poly'
+        if dind.get(ktype) is not None:
 
-            a0 = dout[kfunc]['a0']
-            a1 = dout[kfunc]['a1']
-            a2 = dout[kfunc]['a2']
+            a0 = dout[ktype]['a0']
+            a1 = dout[ktype]['a1']
+            a2 = dout[ktype]['a2']
 
             # integral
             if lamb is not None:
-                dout[kfunc]['integ'] = (
+                dout[ktype]['integ'] = (
                     a0 * (lamb[-1] - lamb[0])
                     + a1 * (lamb[-1]**2 - lamb[0]**2)/2
                 )
 
             # argmax, max
-            dout[kfunc]['argmax'] = np.full(a0.shape, np.nan)
-            dout[kfunc]['max'] = np.full(a1.shape, np.nan)
+            dout[ktype]['argmax'] = np.full(a0.shape, np.nan)
+            dout[ktype]['max'] = np.full(a1.shape, np.nan)
             iok = a2 != 0
-            dout[kfunc]['argmax'][iok] = lambm - lambD * a1[iok]/(2*a2[iok])
-            dout[kfunc]['max'][iok] = a0[iok] - a1[iok]**2 / (4*a2[iok])
+            dout[ktype]['argmax'][iok] = lambm - lambD * a1[iok]/(2*a2[iok])
+            dout[ktype]['max'][iok] = a0[iok] - a1[iok]**2 / (4*a2[iok])
 
         # --------------------
         # sum all exponentials
 
-        kfunc = 'exp_lamb'
-        if dind.get(kfunc) is not None:
+        ktype = 'exp_lamb'
+        if dind.get(ktype) is not None:
 
             # physics
-            rate = dout[kfunc]['rate']
-            dout[kfunc]['Te'] = (scpct.h * scpct.c / rate) / scpct.e
+            rate = dout[ktype]['rate']
+            dout[ktype]['Te'] = (scpct.h * scpct.c / rate) / scpct.e
 
             # integral
             if lamb is not None:
-                amp = dout[kfunc]['rate']
-                dout[kfunc]['integ'] = (
+                amp = dout[ktype]['rate']
+                dout[ktype]['integ'] = (
                     (amp / rate)
                     * (np.exp(lamb[-1] * rate) - np.exp(lamb[0] * rate))
                 )
@@ -350,28 +350,28 @@ def _get_func_moments(
         # -----------------
         # sum all gaussians
 
-        kfunc = 'gauss'
-        if dind.get(kfunc) is not None:
+        ktype = 'gauss'
+        if dind.get(ktype) is not None:
 
-            amp = dout[kfunc]['amp']
-            sigma = dout[kfunc]['sigma']
-            vccos = dout[kfunc]['vccos']
+            amp = dout[ktype]['amp']
+            sigma = dout[ktype]['sigma']
+            vccos = dout[ktype]['vccos']
 
             # argmax
-            dout[kfunc]['argmax'] = _get_line_argmax(
-                vccos, param_val, dind, kfunc, amp.shape, axis,
+            dout[ktype]['argmax'] = _get_line_argmax(
+                vccos, param_val, dind, ktype, amp.shape, axis,
             )
 
             # integral
-            dout[kfunc]['integ'] = amp * sigma * np.sqrt(2 * np.pi)
+            dout[ktype]['integ'] = amp * sigma * np.sqrt(2 * np.pi)
 
             # physics
-            if dind[kfunc].get('mz') is not None:
-                dout[kfunc]['Ti'] = _get_Ti(
+            if dind[ktype].get('mz') is not None:
+                dout[ktype]['Ti'] = _get_Ti(
                     sigma,
                     param_val,
                     dind,
-                    kfunc,
+                    ktype,
                     sigma.shape,
                     axis,
                 )
@@ -379,46 +379,46 @@ def _get_func_moments(
         # -------------------
         # sum all Lorentzians
 
-        kfunc = 'lorentz'
-        if dind.get(kfunc) is not None:
+        ktype = 'lorentz'
+        if dind.get(ktype) is not None:
 
-            amp = dout[kfunc]['amp']
-            gam = dout[kfunc]['gam']
-            vccos = dout[kfunc]['vccos']
+            amp = dout[ktype]['amp']
+            gam = dout[ktype]['gam']
+            vccos = dout[ktype]['vccos']
 
             # argmax
-            dout[kfunc]['argmax'] = _get_line_argmax(
-                vccos, param_val, dind, kfunc, amp.shape, axis,
+            dout[ktype]['argmax'] = _get_line_argmax(
+                vccos, param_val, dind, ktype, amp.shape, axis,
             )
 
             # integral
-            dout[kfunc]['integ'] = amp * np.pi * gam
+            dout[ktype]['integ'] = amp * np.pi * gam
 
         # --------------------
         # sum all pseudo-voigt
 
-        kfunc = 'pvoigt'
-        if dind.get(kfunc) is not None:
+        ktype = 'pvoigt'
+        if dind.get(ktype) is not None:
 
-            amp = dout[kfunc]['amp']
-            sigma = dout[kfunc]['sigma']
-            vccos = dout[kfunc]['vccos']
+            amp = dout[ktype]['amp']
+            sigma = dout[ktype]['sigma']
+            vccos = dout[ktype]['vccos']
 
             # argmax
-            dout[kfunc]['argmax'] = _get_line_argmax(
-                vccos, param_val, dind, kfunc, amp.shape, axis,
+            dout[ktype]['argmax'] = _get_line_argmax(
+                vccos, param_val, dind, ktype, amp.shape, axis,
             )
 
             # integral
-            dout[kfunc]['integ'] = np.full(sigma.shape, np.nan)
+            dout[ktype]['integ'] = np.full(sigma.shape, np.nan)
 
             # physics
-            if dind[kfunc].get('mz') is not None:
-                dout[kfunc]['Ti'] = _get_Ti(
+            if dind[ktype].get('mz') is not None:
+                dout[ktype]['Ti'] = _get_Ti(
                     sigma,
                     param_val,
                     dind,
-                    kfunc,
+                    ktype,
                     sigma.shape,
                     axis,
                 )
@@ -426,28 +426,28 @@ def _get_func_moments(
         # --------------------
         # sum all voigt
 
-        kfunc = 'voigt'
-        if dind.get(kfunc) is not None:
+        ktype = 'voigt'
+        if dind.get(ktype) is not None:
 
-            amp = dout[kfunc]['amp']
-            sigma = dout[kfunc]['sigma']
-            vccos = dout[kfunc]['vccos']
+            amp = dout[ktype]['amp']
+            sigma = dout[ktype]['sigma']
+            vccos = dout[ktype]['vccos']
 
             # argmax
-            dout[kfunc]['argmax'] = _get_line_argmax(
-                vccos, param_val, dind, kfunc, amp.shape, axis,
+            dout[ktype]['argmax'] = _get_line_argmax(
+                vccos, param_val, dind, ktype, amp.shape, axis,
             )
 
             # integral
-            dout[kfunc]['integ'] = amp
+            dout[ktype]['integ'] = amp
 
             # physics
-            if dind[kfunc].get('mz') is not None:
-                dout[kfunc]['Ti'] = _get_Ti(
+            if dind[ktype].get('mz') is not None:
+                dout[ktype]['Ti'] = _get_Ti(
                     sigma,
                     param_val,
                     dind,
-                    kfunc,
+                    ktype,
                     sigma.shape,
                     axis,
                 )
@@ -455,16 +455,16 @@ def _get_func_moments(
         # ------------------
         # sum all pulse_exp
 
-        kfunc = 'pulse_exp'
-        if dind.get(kfunc) is not None:
+        ktype = 'pulse_exp'
+        if dind.get(ktype) is not None:
 
-            amp = dout[kfunc]['amp']
-            tau = dout[kfunc]['tau']
-            t_down = dout[kfunc]['t_down']
-            t_up = dout[kfunc]['t_up']
+            amp = dout[ktype]['amp']
+            tau = dout[ktype]['tau']
+            t_down = dout[ktype]['t_down']
+            t_up = dout[ktype]['t_up']
 
             # integral
-            dout[kfunc]['integ'] = amp * (t_down - t_up)
+            dout[ktype]['integ'] = amp * (t_down - t_up)
 
             # prepare
             t0 = lamb[0] + lambD * tau
@@ -472,11 +472,11 @@ def _get_func_moments(
             lntdu = np.log(t_down / t_up)
 
             # position of max
-            dout[kfunc]['t0'] = t0
-            dout[kfunc]['argmax'] = t0 + lntdu * t_down*t_up / dtdu
+            dout[ktype]['t0'] = t0
+            dout[ktype]['argmax'] = t0 + lntdu * t_down*t_up / dtdu
 
             # value at max
-            dout[kfunc]['max'] = amp * (
+            dout[ktype]['max'] = amp * (
                 np.exp(-lntdu * t_up / dtdu)
                 - np.exp(-lntdu * t_down / dtdu)
             )
@@ -484,50 +484,50 @@ def _get_func_moments(
         # ------------------
         # sum all pulse_gauss
 
-        kfunc = 'pulse_gauss'
-        if dind.get(kfunc) is not None:
+        ktype = 'pulse_gauss'
+        if dind.get(ktype) is not None:
 
-            amp = dout[kfunc]['amp']
-            tau = dout[kfunc]['tau']
-            t_down = dout[kfunc]['t_down']
-            t_up = dout[kfunc]['t_up']
+            amp = dout[ktype]['amp']
+            tau = dout[ktype]['tau']
+            t_down = dout[ktype]['t_down']
+            t_up = dout[ktype]['t_up']
 
             # integral
-            dout[kfunc]['integ'] = amp/2 * np.sqrt(np.pi) * (t_up + t_down)
+            dout[ktype]['integ'] = amp/2 * np.sqrt(np.pi) * (t_up + t_down)
 
             # prepare
             t0 = lamb[0] + lambD * tau
 
             # position of max
-            dout[kfunc]['t0'] = t0
-            dout[kfunc]['argmax'] = t0
+            dout[ktype]['t0'] = t0
+            dout[ktype]['argmax'] = t0
 
             # value at max
-            dout[kfunc]['max'] = amp
+            dout[ktype]['max'] = amp
 
         # ------------------
         # sum all lognorm
 
-        kfunc = 'lognorm'
-        if dind.get(kfunc) is not None:
+        ktype = 'lognorm'
+        if dind.get(ktype) is not None:
 
-            amp = dout[kfunc]['amp']
-            tau = dout[kfunc]['tau']
-            sigma = dout[kfunc]['sigma']
-            mu = dout[kfunc]['mu']
+            amp = dout[ktype]['amp']
+            tau = dout[ktype]['tau']
+            sigma = dout[ktype]['sigma']
+            mu = dout[ktype]['mu']
 
             # integral
-            dout[kfunc]['integ'] = np.full(mu.shape, np.nan)
+            dout[ktype]['integ'] = np.full(mu.shape, np.nan)
 
             # prepare
             t0 = lamb[0] + lambD * tau
 
             # position of max
-            dout[kfunc]['t0'] = t0
-            dout[kfunc]['argmax'] = t0 + np.exp(mu - sigma**2)
+            dout[ktype]['t0'] = t0
+            dout[ktype]['argmax'] = t0 + np.exp(mu - sigma**2)
 
             # value at max
-            dout[kfunc]['max'] = amp * np.exp(0.5*sigma**2 - mu)
+            dout[ktype]['max'] = amp * np.exp(0.5*sigma**2 - mu)
 
         return dout
 
@@ -541,16 +541,16 @@ def _get_func_moments(
 
 
 def _get_var_extract_func(dind, axis, sli):
-    def func(kfunc, kvar, x_full, dind=dind, axis=axis, sli=sli):
-        sli[axis] = dind[kfunc][kvar]['ind']
+    def func(ktype, kvar, x_full, dind=dind, axis=axis, sli=sli):
+        sli[axis] = dind[ktype][kvar]['ind']
         return x_full[tuple(sli)]
     return func
 
 
-def _get_line_argmax(vccos, param_val, dind, kfunc, shape, axis):
+def _get_line_argmax(vccos, param_val, dind, ktype, shape, axis):
 
     # lamb0
-    lamb0 = param_val[dind[kfunc]['lamb0']]
+    lamb0 = param_val[dind[ktype]['lamb0']]
 
     # reshape lamb0
     reshape = [1 for ii in shape]
@@ -560,11 +560,11 @@ def _get_line_argmax(vccos, param_val, dind, kfunc, shape, axis):
     return lamb0 * (1 + vccos)
 
 
-def _get_Ti(sigma, param_val, dind, kfunc, shape, axis):
+def _get_Ti(sigma, param_val, dind, ktype, shape, axis):
 
     # lamb0, mz
-    lamb0 = param_val[dind[kfunc]['lamb0']]
-    mz = param_val[dind[kfunc]['mz']]
+    lamb0 = param_val[dind[ktype]['lamb0']]
+    mz = param_val[dind[ktype]['mz']]
 
     # reshape lamb0 and mz
     reshape = [1 for ii in shape]
@@ -600,17 +600,31 @@ def _format(
     # loop
     # --------------
 
-    for kfunc, v0 in _model_dict._DMODEL.items():
+    for ktype, vtype in din.items():
 
-        if dind.get(kfunc) is not None:
+        lkfunc =
+        lind =
+
+        for kout, vout in vtype.items():
+
+            for ii in range(dout[ktype][kvar].shape[axis]):
+
+                key = f"{ktype}_{kvar}"
+                dout[]
+
+
+    for ktype, v0 in _model_dict._DMODEL.items():
+
+        if dind.get(ktype) is not None:
 
             for kvar in v0['var']:
 
                 key = f"{kfunc}_{kvar}"
 
-                for in ...:
+                for ii in range(dout[ktype][kvar].shape[axis]):
+                    kfunc =
                     sli =
-                    key =
+                    key = f"{kfunc}_{kvar}"
                     assert key in lx_all, key
 
                     # get units

--- a/spectrally/_class01_moments.py
+++ b/spectrally/_class01_moments.py
@@ -238,8 +238,9 @@ def _get_func_moments(
 
         if c0 is None:
             x_full = x_free
-            xf_min = x_full - x_std
-            xf_max = x_full + x_std
+            if x_std is not None:
+                xf_min = x_full - x_std
+                xf_max = x_full + x_std
 
         else:
 
@@ -276,8 +277,9 @@ def _get_func_moments(
 
             else:
                 x_full = c2.dot(x_free**2) + c1.dot(x_free) + c0
-                xf_min = c2.dot((x_free - x_std)**2) + c1.dot(x_free - x_std) + c0
-                xf_max = c2.dot((x_free + x_std)**2) + c1.dot(x_free + x_std) + c0
+                if x_std is not None:
+                    xf_min = c2.dot((x_free - x_std)**2) + c1.dot(x_free - x_std) + c0
+                    xf_max = c2.dot((x_free + x_std)**2) + c1.dot(x_free + x_std) + c0
 
         sli = [None if ii == axis else slice(None) for ii in range(x_free.ndim)]
         extract = _get_var_extract_func(dind, axis, sli)

--- a/spectrally/_class01_moments.py
+++ b/spectrally/_class01_moments.py
@@ -651,7 +651,8 @@ def _format(
 
 def _units(coll, ktype, kvar, units_data=None, units_lamb=None):
 
-    kvar = kvar.split('_')[0]
+    if kvar.endswith('_min') or kvar.endswith('_max'):
+        kvar = kvar[:-4]
     units = None
 
     # ------------

--- a/spectrally/_class01_moments.py
+++ b/spectrally/_class01_moments.py
@@ -305,6 +305,7 @@ def _get_func_moments(
                 dout[ktype]['integ'] = (
                     a0 * (lamb[-1] - lamb[0])
                     + a1 * (lamb[-1]**2 - lamb[0]**2)/2
+                    + a2 * (lamb[-1]**3 - lamb[0]**3)/3
                 )
 
             # argmax, max

--- a/spectrally/tests/_hxr_pulses.py
+++ b/spectrally/tests/_hxr_pulses.py
@@ -93,6 +93,15 @@ def main(
     # spectral models
     # --------------
 
+    # spectral constrainst
+    dconstraints = {
+        'gbck': {
+            'ref': 'bck_a0',
+            'bck_a1': [0, 0, 0],
+            'bck_a2': [0, 0, 0],
+        },
+    }
+
     # single exponential pulse
     coll.add_spectral_model(
         key='sm_exp',
@@ -100,9 +109,7 @@ def main(
             'bck': 'poly',
             'pulse': 'pulse_exp',
         },
-        dconstraints={
-            'gbck': {'ref': 'bck_a0', 'bck_a1': [0, 0, 0]},
-        },
+        dconstraints=dconstraints,
     )
 
     # single gaussian pulse
@@ -112,9 +119,7 @@ def main(
             'bck': 'poly',
             'pulse': 'pulse_gauss',
         },
-        dconstraints={
-            'gbck': {'ref': 'bck_a0', 'bck_a1': [0, 0, 0]},
-        },
+        dconstraints=dconstraints,
     )
 
     # single lognorm pulse
@@ -124,9 +129,7 @@ def main(
             'bck': 'poly',
             'pulse': 'lognorm',
         },
-        dconstraints={
-            'gbck': {'ref': 'bck_a0', 'bck_a1': [0, 0, 0]},
-        },
+        dconstraints=dconstraints,
     )
 
     # --------------

--- a/spectrally/tutorials/tutorial.py
+++ b/spectrally/tutorials/tutorial.py
@@ -435,7 +435,7 @@ def _add_spectral_fit(coll=None, data=None):
 
         for k0 in coll.dobj['spect_model'].keys():
             coll.add_spectral_fit(
-                key=f"sf_{k0.replace('sm_', '')}",
+                key=k0.replace('sm_', 'sf_'),
                 key_model=k0,
                 key_data='current',
                 key_sigma=None,


### PR DESCRIPTION
Main changes:
----------------

* `get_spectral_model_moments()` now:
    - return a variable-name-based single-layer dict (`returnas='dict_varnames'`, default)
    - returns `units` and `ref` for all moments
    - return `min` and `max` values for variables only, if `std` available 

Issues:
---------

Fixes, in devel, issue #45 


Examples:
-----------
```
import spectrally as sp

coll = sp.tutorials.main(solver='scipy.curve_fit', data='hxr', compute=False)

coll.compute_spectral_fit('sf_lognorm', chain=False, solver='scipy.curve_fit', overwrite=True)

dout = coll.get_spectral_model_moments('sf_lognorm')
```

Then:
```
[(k0, v0['units']) for k0, v0 in dout.items()]

[('p0_amp', 'A x index'),
 ('p0_amp_min', 'A x index'),
 ('p0_amp_max', 'A x index'),
 ('p0_tau', Unit(dimensionless)),
 ('p0_tau_min', Unit(dimensionless)),
 ('p0_tau_max', Unit(dimensionless)),
 ('p0_mu', 'TBD'),
 ('p0_mu_min', 'TBD'),
 ('p0_mu_max', 'TBD'),
 ('p0_sigma', Unit(dimensionless)),
 ('p0_sigma_min', Unit(dimensionless)),
 ('p0_sigma_max', Unit(dimensionless)),
 ('p0_integ', 'A x index'),
 ('p0_t0', 'index'),
 ('p0_argmax', 'index'),
 ('p0_max', Unit("A")),
 ('bck_a0', Unit("A")),
 ('bck_a0_min', Unit("A")),
 ('bck_a0_max', Unit("A")),
 ('bck_a1', Unit("A")),
 ('bck_a1_min', Unit("A")),
 ('bck_a1_max', Unit("A")),
 ('bck_a2', Unit("A")),
 ('bck_a2_min', Unit("A")),
 ('bck_a2_max', Unit("A")),
 ('bck_integ', 'A x index'),
 ('bck_argmax', 'index'),
 ('bck_max', Unit("A"))]
```