### PR TITLE
Lines labelling

### DIFF
--- a/spectrally/_class00_SpectralLines.py
+++ b/spectrally/_class00_SpectralLines.py
@@ -338,7 +338,12 @@ class SpectralLines(Previous):
     # get labels
     # ---------------
 
-    def get_spectral_lines_labels(self, keys=None, labels=None):
+    def get_spectral_lines_labels(
+        self,
+        keys=None,
+        labels=None,
+        colors=None,
+    ):
         """ Return a dict of {key: label}
 
         Typically used to customize spectral lines labelling
@@ -376,6 +381,7 @@ class SpectralLines(Previous):
             coll=self,
             keys=keys,
             labels=labels,
+            colors=colors,
         )
 
     # -----------------

--- a/spectrally/_class00_SpectralLines.py
+++ b/spectrally/_class00_SpectralLines.py
@@ -13,6 +13,7 @@ from bsplines2d import BSplines2D as Previous
 from . import _class00_check_ion as _check_ion
 from . import _class00_check_lines as _check_lines
 from . import _class00_compute as _compute
+from . import _class00_lines_labels as _labels
 from . import _class00_plot as _plot
 
 
@@ -332,6 +333,50 @@ class SpectralLines(Previous):
         if returnas is dict:
             out = {k0: out[ii] for ii, k0 in enumerate(key)}
         return out
+
+    # ---------------
+    # get labels
+    # ---------------
+
+    def get_spectral_lines_labels(self, keys=None, labels=None):
+        """ Return a dict of {key: label}
+
+        Typically used to customize spectral lines labelling
+
+        If keys is a key to a spectral model or spectral fit, the spectral
+        lines are actually the names of all model functions that can be peaked,
+        which includes the following:
+                - gauss
+                - lorentz
+                - pvoigt
+                - pulse_exp
+                - pulse_gauss
+
+        Parameters
+        ----------
+        keys:     str / list of str
+            Can be either:
+                - key of list of keys of valid spectral lines
+                - key of a valid spectral model
+                - key of a valid spectral fit
+
+        labels:   str / dict
+            Can be either:
+                - str: a valid spectral line parameter
+                    e.g.: 'symbol', 'ion', ...
+                - dict: a custom dict of {key: label}
+
+        Returns
+        -------
+        dlabels:  dict
+            dict of {key: label}
+
+        """
+        return _labels.main(
+            coll=self,
+            keys=keys,
+            labels=labels,
+        )
 
     # -----------------
     # PEC interpolation

--- a/spectrally/_class00_lines_labels.py
+++ b/spectrally/_class00_lines_labels.py
@@ -6,9 +6,9 @@ Created on Fri Aug 30 08:04:47 2024
 """
 
 
+import matplotlib.pyplot as plt
+import matplotlib.colors as mcolors
 import datastock as ds
-
-
 
 
 # ##################################################################
@@ -21,16 +21,18 @@ def main(
     coll=None,
     keys=None,
     labels=None,
+    colors=None,
 ):
 
     # ---------------
     # check inputs
     # ---------------
 
-    keys = _check(
+    keys, defcolor, colors = _check(
         coll=coll,
         keys=keys,
         labels=labels,
+        colors=colors,
     )
 
     # ----------------
@@ -39,22 +41,61 @@ def main(
 
     if labels is None:
 
-        dlabels = {k0: k0 for k0 in keys}
+        dlabels = {k0: {'label': k0} for k0 in keys}
 
     elif isinstance(labels, str):
 
         wsl = coll._which_lines
         dlabels = {
-            k0: coll.dobj[wsl].get(k0, {}).get(labels, k0)
+            k0: {'label': coll.dobj[wsl].get(k0, {}).get(labels, k0)}
             for k0 in keys
         }
 
     else:
 
         dlabels = {
-            k0: labels.get(k0, k0)
+            k0: {'label': labels.get(k0, k0)}
             for k0 in keys
         }
+
+    # ----------------
+    # colors
+    # ----------------
+
+    if colors is None:
+
+        for k0 in dlabels.keys():
+            dlabels[k0]['color'] = defcolor
+
+    elif isinstance(colors, str):
+
+        if mcolors.is_color_like(colors):
+            for k0 in dlabels.keys():
+                dlabels[k0]['color'] = colors
+
+        elif colors in ['sum', 'details']:
+            pass
+
+        else:
+            wsl = coll._which_lines
+
+            # get unique values
+            lunique = set([
+                coll.dobj[wsl].get(k0, {}).get(colors, k0)
+                for k0 in dlabels.keys()
+            ])
+
+            # get color cycle and loop
+            color_cycle = plt.rcParams['axes.prop_cycle'].by_key()['color']
+            for ii, uu in enumerate(lunique):
+                for k0 in dlabels.keys():
+                    if coll.dobj[wsl].get(k0, {}).get(colors, k0) == uu:
+                        dlabels[k0]['color'] = color_cycle[ii]
+
+    else:
+
+        for k0 in dlabels.keys():
+            dlabels[k0]['color'] = colors.get(k0, defcolor)
 
     return dlabels
 
@@ -69,6 +110,7 @@ def _check(
     coll=None,
     keys=None,
     labels=None,
+    colors=None,
 ):
 
     # ----------------
@@ -140,7 +182,7 @@ def _check(
             msg = (
                 "Arg 'labels', if str, must be a spectral line parameter!\n"
                 "\t available: {lparam}\n"
-                f"\t Provided: {labels}\n"
+                f"\t Provided: '{labels}'\n"
             )
             raise Exception(msg)
 
@@ -170,4 +212,76 @@ def _check(
         )
         raise Exception(msg)
 
-    return keys
+    # ----------------
+    # colors
+    # ----------------
+
+    # default
+    defcolor = 'k'
+    if colors is None:
+        if coll.dobj.get(wsl) is None:
+            colors = defcolor
+        else:
+            colors = 'ion'
+
+    # case by case
+    if isinstance(colors, str):
+
+        if mcolors.is_color_like(colors):
+            pass
+
+        elif colors in ['sum', 'details']:
+            pass
+
+        else:
+
+            if coll.dobj.get(wsl) is None:
+                msg = (
+                    "Arg 'colors', if str and not any of these:\n"
+                    "\t- any color-like str\n"
+                    "\t- 'sum'\n"
+                    "\t- 'details'\n"
+                    "Then must be a spectral line parameter!\n"
+                    "But you apparently have no spectral lines in your Collection!"
+                    f"\nProvided: '{colors}'\n"
+                )
+                raise Exception(msg)
+
+            lparam = coll.get_lparam(wsl)
+
+            if colors not in lparam:
+                msg = (
+                    "Arg 'colors', if str, must be a spectral line parameter!\n"
+                    "\t available: {lparam}\n"
+                    f"\t Provided: '{colors}'\n"
+                )
+                raise Exception(msg)
+
+    elif isinstance(colors, dict):
+
+        c0 = all([
+            isinstance(k0, str)
+            and k0 in keys
+            and isinstance(v0, str)
+            for k0, v0 in colors.items()
+        ])
+        if not c0:
+            msg = (
+                "Arg 'colors', if dict, must be of the form:\n"
+                "\t- dict: {'key0': 'color0', 'key1': 'color1', ...}\n"
+                f"Provided:\n{colors}\n"
+            )
+            raise Exception(msg)
+
+    elif colors is not None:
+        msg = (
+            "Arg 'colors' must be either:\n"
+            "\t- str: a valid color-like str, 'sum', 'details' "
+            "or a valid spectral line parameter"
+            "\t\t e.g: 'symbol', 'ion', ...\n"
+            "\t- dict: {'key0': 'color0', 'key1': 'color1', ...}\n"
+            f"Provided:\n{colors}\n"
+        )
+        raise Exception(msg)
+
+    return keys, defcolor, colors

--- a/spectrally/_class00_lines_labels.py
+++ b/spectrally/_class00_lines_labels.py
@@ -1,0 +1,173 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Fri Aug 30 08:04:47 2024
+
+@author: dvezinet
+"""
+
+
+import datastock as ds
+
+
+
+
+# ##################################################################
+# ##################################################################
+#                    main
+# ##################################################################
+
+
+def main(
+    coll=None,
+    keys=None,
+    labels=None,
+):
+
+    # ---------------
+    # check inputs
+    # ---------------
+
+    keys = _check(
+        coll=coll,
+        keys=keys,
+        labels=labels,
+    )
+
+    # ----------------
+    # labels
+    # ----------------
+
+    if labels is None:
+
+        dlabels = {k0: k0 for k0 in keys}
+
+    elif isinstance(labels, str):
+
+        wsl = coll._which_lines
+        dlabels = {
+            k0: coll.dobj[wsl].get(k0, {}).get(labels, k0)
+            for k0 in keys
+        }
+
+    else:
+
+        dlabels = {
+            k0: labels.get(k0, k0)
+            for k0 in keys
+        }
+
+    return dlabels
+
+
+# ##################################################################
+# ##################################################################
+#                    check
+# ##################################################################
+
+
+def _check(
+    coll=None,
+    keys=None,
+    labels=None,
+):
+
+    # ----------------
+    # keys
+    # ----------------
+
+    # which
+    wsl = coll._which_lines
+    wsm = coll._which_model
+    wsf = coll._which_fit
+
+    # lok
+    lok_lines = list(coll.dobj.get(wsl, {}).keys())
+    lok_model = list(coll.dobj.get(wsm, {}).keys())
+    lok_fit = list(coll.dobj.get(wsf, {}).keys())
+
+    # --------
+    # deal with by case
+
+    if isinstance(keys, str):
+
+        if keys in lok_fit + lok_model:
+
+            if keys in lok_fit:
+                keym = coll.dobj[wsf][keys][wsm]
+            else:
+                keym = keys
+
+            keys = [
+                k0 for k0, v0 in coll.dobj[wsm][keym]['dmodel'].items()
+                if v0['type'] not in ['poly', 'exp_lamb']
+            ]
+            lok = keys
+
+        else:
+            keys = [keys]
+            lok = lok_lines
+
+    else:
+        lok = lok_lines
+
+    # ----------
+    # check
+
+    keys = ds._generic_check._check_var_iter(
+        keys, 'keys',
+        types=(list, tuple),
+        types_iter=str,
+        allowed=lok,
+    )
+
+    # ----------------
+    # labels
+    # ----------------
+
+    if isinstance(labels, str):
+
+        if coll.dobj.get(wsl) is None:
+            msg = (
+                "Arg 'labels', if str, must be a spectral line parameter!\n"
+                "But you apparently have no spectral lines in your Collection!"
+                f"\nProvided: '{labels}'\n"
+            )
+            raise Exception(msg)
+
+        lparam = coll.get_lparam(wsl)
+
+        if labels not in lparam:
+            msg = (
+                "Arg 'labels', if str, must be a spectral line parameter!\n"
+                "\t available: {lparam}\n"
+                f"\t Provided: {labels}\n"
+            )
+            raise Exception(msg)
+
+    elif isinstance(labels, dict):
+
+        c0 = all([
+            isinstance(k0, str)
+            and k0 in keys
+            and isinstance(v0, str)
+            for k0, v0 in labels.items()
+        ])
+        if not c0:
+            msg = (
+                "Arg 'labels', if dict, must be of the form:\n"
+                "\t- dict: {'key0': 'label0', 'key1': 'label1', ...}\n"
+                f"Provided:\n{labels}\n"
+            )
+            raise Exception(msg)
+
+    elif labels is not None:
+        msg = (
+            "Arg 'labels' must be either:\n"
+            "\t- str: a valid spectral line parameter"
+            "\t\t e.g: 'symbol', 'ion', ...\n"
+            "\t- dict: {'key0': 'label0', 'key1': 'label1', ...}\n"
+            f"Provided:\n{labels}\n"
+        )
+        raise Exception(msg)
+
+    return keys

--- a/spectrally/_class02_SpectralFit.py
+++ b/spectrally/_class02_SpectralFit.py
@@ -217,12 +217,23 @@ class SpectralFit(Previous):
         dprop=None,
         vmin=None,
         vmax=None,
+        # lines labels
+        lines_labels=True,
+        lines_labels_color=None,
+        lines_labels_rotation=None,
+        lines_labels_horizontalalignment=None,
         # figure
         dax=None,
         fs=None,
         dmargin=None,
         tit=None,
+        # interactivity
+        nmax=None,
+        connect=None,
+        dinc=None,
+        show_commands=None,
     ):
+
         """ Plot a spectral model using specified data
 
         lamb can be:
@@ -241,9 +252,19 @@ class SpectralFit(Previous):
             dprop=dprop,
             vmin=vmin,
             vmax=vmax,
+            # lines labels
+            lines_labels=lines_labels,
+            lines_labels_color=lines_labels_color,
+            lines_labels_rotation=lines_labels_rotation,
+            lines_labels_horizontalalignment=lines_labels_horizontalalignment,
             # figure
             dax=dax,
             fs=fs,
             dmargin=dmargin,
             tit=tit,
+            # interactivity
+            nmax=nmax,
+            connect=connect,
+            dinc=dinc,
+            show_commands=show_commands,
         )

--- a/spectrally/tutorials/tutorial.py
+++ b/spectrally/tutorials/tutorial.py
@@ -345,6 +345,30 @@ def _add_data(coll=None, data=None):
             units='counts',
         )
 
+        # --------------
+        # add spectral lines
+
+        coll.add_spectral_line(
+            key='l0',
+            ion='Ar16+',
+            lamb0=2.719e-10,
+            source='user',
+        )
+
+        coll.add_spectral_line(
+            key='l1',
+            ion='Ar15+',
+            lamb0=2.726e-10,
+            source='user',
+        )
+
+        coll.add_spectral_line(
+            key='l2',
+            ion='Ar16+',
+            lamb0=2.735e-10,
+            source='user',
+        )
+
     # ------------
     # Error
     # ------------
@@ -460,9 +484,9 @@ def _add_spectral_model(coll=None, data=None):
             key='sm0',
             dmodel={
                 'bck': 'poly',
-                'l0': {'type': 'gauss', 'lamb0': 2.719e-10, 'mz': mz},
-                'l1': {'type': 'gauss', 'lamb0': 2.726e-10, 'mz': mz},
-                'l2': {'type': 'gauss', 'lamb0': 2.735e-10, 'mz': mz},
+                'l0': {'type': 'gauss'},
+                'l1': {'type': 'gauss'},
+                'l2': {'type': 'gauss'},
             },
             dconstraints={
                 'g0': {

--- a/spectrally/tutorials/tutorial.py
+++ b/spectrally/tutorials/tutorial.py
@@ -159,7 +159,7 @@ def main(
         else:
             dout = coll.get_spectral_model_moments('sf_exp')
 
-    return coll
+    return coll, dax, dout
 
 
 # ######################################################


### PR DESCRIPTION
Main changes:
----------------

* requires `datastock >= 0.0.40` (next release), or devel branch past [PR 161](https://github.com/ToFuProject/datastock/pull/161)
* `tutorial` now returns `coll, dax, dout` 
* `get_spectral_lines_labels(keys=list, labels=str or dict, colors=str or dict)` implemented
* `plot_spectral_fit(lines_labels=str or dict)` implemented with good customization options
    - labels can be customized
    - colors can be customized
    - works with time-dependent spectra (dynamic positioning)

Issues:
--------

Fixes, in devel, issue #54 

TODO:  #63 


Examples:
-----------
```
import spectrally as sp
coll, dax, dout = sp.tutorials.main(data='ebit', chain=False, binning=False)
```

![image](https://github.com/user-attachments/assets/b6e98b63-589f-49a1-86e7-4c869eeca61d)