### PR TITLE
Faster `plots_specral_fit()` thanks to better uncertainty propagation

### DIFF
--- a/spectrally/_class01_SpectralModel.py
+++ b/spectrally/_class01_SpectralModel.py
@@ -154,10 +154,14 @@ class SpectralModel(Previous):
         # options
         details=None,
         binning=None,
+        # uncertainty propagation
+        uncertainty_method=None,
         # others
         returnas=None,
         store=None,
         store_key=None,
+        # timing
+        timing=None,
     ):
         """ Interpolate the spectral model at lamb using key_data
 
@@ -187,10 +191,14 @@ class SpectralModel(Previous):
             # options
             details=details,
             binning=binning,
+            # uncertainty propagation
+            uncertainty_method=uncertainty_method,
             # others
             returnas=returnas,
             store=store,
             store_key=store_key,
+            # timing
+            timing=timing,
         )
 
     # ----------------------

--- a/spectrally/_class01_interpolate.py
+++ b/spectrally/_class01_interpolate.py
@@ -411,7 +411,7 @@ def _check(
     uncertainty_method = ds._generic_check._check_var(
         uncertainty_method, 'uncertainty_method',
         types=str,
-        default='min/max',
+        default='standard',
         allowed=['standard', 'min/max'],
     )
 

--- a/spectrally/_class01_moments.py
+++ b/spectrally/_class01_moments.py
@@ -47,7 +47,7 @@ def main(
     # all other variables
     (
         key_model, ref_nx, ref_nf,
-        key_data, key_std,
+        key_data, key_cov,
         key_lamb, lamb, ref_lamb,
         binning, details,
         _,
@@ -113,7 +113,7 @@ def main(
 
     dout = func(
         x_free=coll.ddata[key_data]['data'],
-        x_std=None if key_std is None else coll.ddata[key_std]['data'],
+        x_cov=None if key_cov is None else coll.ddata[key_cov]['data'],
         lamb=lamb,
     )
 
@@ -212,7 +212,7 @@ def _get_func_moments(
 
     def func(
         x_free=None,
-        x_std=None,
+        x_cov=None,
         lamb=None,
         param_val=param_val,
         c0=c0,
@@ -235,6 +235,14 @@ def _get_func_moments(
             k0: {} for k0 in dind.keys()
             if k0 not in ['func', 'nfunc', 'jac']
         }
+
+        # --------------------
+        # cov to std
+
+        if x_cov is not None:
+            x_std = np.sqrt(np.diagonal(x_cov, axis1=-2, axis2=-1))
+        else:
+            x_std = None
 
         # ----------------------------
         # get x_full from constraints

--- a/spectrally/_class01_moments.py
+++ b/spectrally/_class01_moments.py
@@ -50,7 +50,9 @@ def main(
         key_data, key_std,
         key_lamb, lamb, ref_lamb,
         binning, details,
+        _,
         _, store, store_key,
+        _,
     ) = _interpolate._check(
         coll=coll,
         key_model=key,

--- a/spectrally/_class02_SpectralFit.py
+++ b/spectrally/_class02_SpectralFit.py
@@ -290,6 +290,8 @@ class SpectralFit(Previous):
         connect=None,
         dinc=None,
         show_commands=None,
+        # timing
+        timing=None,
     ):
 
         """ Plot a spectral model using specified data
@@ -325,4 +327,6 @@ class SpectralFit(Previous):
             connect=connect,
             dinc=dinc,
             show_commands=show_commands,
+            # timing
+            timing=timing,
         )

--- a/spectrally/_class02_SpectralFit.py
+++ b/spectrally/_class02_SpectralFit.py
@@ -271,6 +271,8 @@ class SpectralFit(Previous):
         keyY=None,
         # options
         details=None,
+        # uncertainty propagation
+        uncertainty_method=None,
         # plotting
         dprop=None,
         vmin=None,
@@ -308,6 +310,8 @@ class SpectralFit(Previous):
             keyY=keyY,
             # options
             details=details,
+            # uncertainty propagation
+            uncertainty_method=uncertainty_method,
             # plotting
             dprop=dprop,
             vmin=vmin,

--- a/spectrally/_class02_check_fit.py
+++ b/spectrally/_class02_check_fit.py
@@ -161,7 +161,7 @@ def _check(
                 'key_bs': key_bs,
                 'key_bs_vect': key_bs_vect,
                 'key_sol': None,
-                'key_std': None,
+                'key_cov': None,
                 'dparams': dparams,
                 'dvalid': dvalid,
             },

--- a/spectrally/_class02_compute_fit.py
+++ b/spectrally/_class02_compute_fit.py
@@ -96,6 +96,7 @@ def main(
     if data.ndim == 1:
         # don't change axis !
         data = data[:, None]
+        shape_cov = (1,) + shape_cov
         ravel = True
 
     # ------------

--- a/spectrally/_class02_compute_fit_1d.py
+++ b/spectrally/_class02_compute_fit_1d.py
@@ -434,7 +434,8 @@ def _loop(
         slii = tuple(sli_sol)
 
         # covariance
-        sli_cov[ind_cov] = ind
+        if cov is not None:
+            sli_cov[ind_cov] = ind
 
         # ---------------
         # x0

--- a/spectrally/_class02_compute_fit_1d.py
+++ b/spectrally/_class02_compute_fit_1d.py
@@ -34,6 +34,9 @@ def main(
     key_model=None,
     key_data=None,
     key_lamb=None,
+    # covarance
+    ref_cov=None,
+    shape_cov=None,
     # lamb, data, axis
     lamb=None,
     data=None,
@@ -186,6 +189,9 @@ def main(
         lamb=lamb,
         data=data,
         axis=axis,
+        # covarance
+        ref_cov=ref_cov,
+        shape_cov=shape_cov,
         # iok
         dind=dind,
         iok_all=iok_all,
@@ -270,6 +276,9 @@ def _loop(
     lamb=None,
     data=None,
     axis=None,
+    # covarance
+    ref_cov=None,
+    shape_cov=None,
     # iok
     dind=None,
     iok_all=None,
@@ -363,10 +372,17 @@ def _loop(
     nfev = np.full(shape_reduced, np.nan)
     time = np.full(shape_reduced, np.nan)
     sol = np.full(shape_sol, np.nan)
+
+    # covariance matrix
     if solver == 'scipy.curve_fit':
-        std = np.full(shape_sol, np.nan)
+        cov = np.full(shape_cov, np.nan)
+        sli_cov = np.r_[
+            [0 for ii in shape_reduced] + [slice(None), slice(None)]
+        ]
+        ind_cov = np.arange(len(shape_reduced))
+        scales_cov = scales[:, None] * scales[None, :]
     else:
-        std = None
+        cov = None
 
     message = ['' for ii in range(np.prod(shape_reduced))]
     errmsg = ['' for ii in range(np.prod(shape_reduced))]
@@ -416,6 +432,9 @@ def _loop(
 
         sli_sol[ind_ind] = ind
         slii = tuple(sli_sol)
+
+        # covariance
+        sli_cov[ind_cov] = ind
 
         # ---------------
         # x0
@@ -537,7 +556,7 @@ def _loop(
 
                 # store scaled solution
                 sol[slii] = popt * scales
-                std[slii] = np.sqrt(np.diag(pcov)) * scales
+                cov[tuple(sli_cov)] = pcov * scales_cov
 
                 # message
                 message[ii] = mesg
@@ -605,7 +624,10 @@ def _loop(
     dout = {
         'validity': validity,
         'sol': sol,
-        'std': std,
+        # covariance
+        'cov': cov,
+        'ref_cov': ref_cov,
+        # output
         'msg': np.reshape(message, shape_reduced),
         'nfev': nfev,
         'cost': cost,

--- a/spectrally/_class02_plot_fit.py
+++ b/spectrally/_class02_plot_fit.py
@@ -6,6 +6,9 @@ Created on Sat Mar  9 16:09:08 2024
 """
 
 
+import datetime as dtm
+
+
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib import gridspec
@@ -47,6 +50,8 @@ def main(
     connect=None,
     dinc=None,
     show_commands=None,
+    # timing
+    timing=None,
 ):
 
     # -------------------
@@ -59,6 +64,7 @@ def main(
         lines_labels, dlabels, lines_labels_rotation,
         lines_labels_horizontalalignment,
         connect,
+        timing,
     ) = _check(
         coll=coll,
         key=key,
@@ -72,7 +78,14 @@ def main(
         # interactivity
         nmax=nmax,
         connect=connect,
+        # timing
+        timing=timing,
     )
+
+    if timing is True:
+        print()
+        fname = 'plot_spectral_fit()'
+        t1 = dtm.datetime.now()  # DB
 
     # -------------------
     # interpolate
@@ -84,7 +97,13 @@ def main(
         details=details,
         # others
         returnas=dict,
+        # timing
+        timing=timing,
     )
+
+    if timing is True:
+        t2 = dtm.datetime.now()  # DB
+        print(f'... timing {fname}: interpolate {(t2-t1).total_seconds()} s')
 
     # -------------------
     # extract coll2
@@ -98,6 +117,10 @@ def main(
         details=details,
         keyY=keyY,
     )
+
+    if timing is True:
+        t3 = dtm.datetime.now()  # DB
+        print(f'... timing {fname}: extract {(t3-t2).total_seconds()} s')
 
     # -------------------
     # prepare figure
@@ -116,6 +139,10 @@ def main(
         )
 
     dax = ds._generic_check._check_dax(dax)
+
+    if timing is True:
+        t4 = dtm.datetime.now()  # DB
+        print(f'... timing {fname}: get_dax {(t4-t3).total_seconds()} s')
 
     # -------------------
     # plot
@@ -155,6 +182,10 @@ def main(
             lines_labels_horizontalalignment=lines_labels_horizontalalignment,
         )
 
+    if timing is True:
+        t5 = dtm.datetime.now()  # DB
+        print(f'... timing {fname}: plot {(t5-t4).total_seconds()} s')
+
     # -------------------
     # finalize
     # -------------------
@@ -164,6 +195,10 @@ def main(
         dout=dout,
         tit=tit,
     )
+
+    if timing is True:
+        t6 = dtm.datetime.now()  # DB
+        print(f'... timing {fname}: finalize {(t6-t5).total_seconds()} s')
 
     # ---------------------
     # connect interactivity
@@ -178,6 +213,10 @@ def main(
             dax.connect()
 
             dax.show_commands(verb=show_commands)
+
+            if timing is True:
+                t7 = dtm.datetime.now()  # DB
+                print(f'... timing {fname}: connect {(t7-t6).total_seconds()} s\n')
             return dax
         else:
             return dax, dgroup
@@ -202,6 +241,8 @@ def _check(
     # interactivity
     nmax=None,
     connect=None,
+    # timing
+    timing=None,
 ):
 
     # -------------
@@ -284,12 +325,23 @@ def _check(
         default=True,
     )
 
+    # -------------
+    # timing
+    # -------------
+
+    timing = ds._generic_check._check_var(
+        timing, 'timing',
+        types=bool,
+        default=True,
+    )
+
     return (
         key, key_model, key_sol, key_data, key_lamb,
         details, binning,
         lines_labels, dlabels, lines_labels_rotation,
         lines_labels_horizontalalignment,
         connect,
+        timing,
     )
 
 

--- a/spectrally/_class02_plot_fit.py
+++ b/spectrally/_class02_plot_fit.py
@@ -31,6 +31,8 @@ def main(
     keyY=None,
     # options
     details=None,
+    # uncertainty propagation
+    uncertainty_method=None,
     # plotting
     dprop=None,
     vmin=None,
@@ -95,6 +97,8 @@ def main(
         key_model=key_fit,
         # options
         details=details,
+        # uncertainty propagation
+        uncertainty_method=uncertainty_method,
         # others
         returnas=dict,
         # timing
@@ -456,7 +460,7 @@ def _plot_1d(
                 )
 
         # ------------
-        # plot std
+        # plot uncertainty
         # -----------
 
         if dkeys.get('sum_min') is not None:
@@ -585,6 +589,12 @@ def _plot_2d(
         connect=False,
         inplace=True,
     )
+
+    # --------------
+    # plot uncertainty
+    # --------------
+
+
 
     # -----------------
     # adjust colors

--- a/spectrally/tutorials/tutorial.py
+++ b/spectrally/tutorials/tutorial.py
@@ -127,6 +127,8 @@ def main(
     # compute spectral fit
     # ---------------------
 
+    dax = None
+    dout = None
     if compute is True:
 
         _compute_spectral_fit(


### PR DESCRIPTION
Main changes:
----------------

* `plot_spectral_fit(timing=bool)` implemented for debugging, left for possible future use
* `compute_spectral_fit()` now saves the full covariance matrix instead of just the standard deviation
* Use of covariance matrix is propagated to the following methods accordingly:
    - `interpolate_spectral_model(uncertainty_method=str)` implemented
    - `get_spectral_model_moments()`: partially adapted, only uses covariance to derive standard deviation at this point
 
The use of the covariance matrix with the spectral model's jacobian allows for a more accurate and mush faster (x1000) computation of the error bar on the summed function.

It solves the problem of slow plotting.
It also prepares the code for further development like:
    - issue #75 
    - issue #76 
    - issue #49 

Issues:
-------

Fixes, in devel, issue #73 


Examples:
------------

The following shows the error bar (uncertainty) computed from the fit of EBIT data with both methods:
- 'min/max' (grey): the original overestimate that computes all combinations of variable values +/- standard deviations
- 'standard' (yellow): the new default, which uses the covariance and jacobian matrices, taking into account the fact that some variables are not independent

The computation time of the error bar is indicated in the legend, showing the dramatic improvement.

![image](https://github.com/user-attachments/assets/f897f548-0d4c-4ed1-aa7d-ee3eb090ab18)

 