### PR TITLE
Better handling of error bar on input data `'key_sigma'` for covariance matrix calculation + better `show('spect_fit')`

### DIFF
--- a/.github/workflows/python-testing-matrix.yml
+++ b/.github/workflows/python-testing-matrix.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v2

--- a/spectrally/_class02_SpectralFit.py
+++ b/spectrally/_class02_SpectralFit.py
@@ -7,8 +7,8 @@ import copy
 
 from ._class01_SpectralModel import SpectralModel as Previous
 from . import _class02_check_fit as _check_fit
+from . import _class02_show as _show
 from . import _class02_binning as _binning
-from . import _class01_fit_func as _fit_func
 from . import _class02_compute_fit as _compute_fit
 from . import _class02_plot_valid as _plot_valid
 from . import _class02_plot_fit as _plot_fit
@@ -40,7 +40,7 @@ class SpectralFit(Previous):
 
     def _get_show_obj(self, which=None):
         if which == self._which_fit:
-            return _check_fit._show
+            return _show._show
         else:
             return super()._get_show_obj(which)
 

--- a/spectrally/_class02_SpectralFit.py
+++ b/spectrally/_class02_SpectralFit.py
@@ -60,6 +60,7 @@ class SpectralFit(Previous):
         key_model=None,
         key_data=None,
         key_sigma=None,
+        absolute_sigma=None,
         # wavelength
         key_lamb=None,
         # optional 2d fit
@@ -79,6 +80,7 @@ class SpectralFit(Previous):
             key_model=key_model,
             key_data=key_data,
             key_sigma=key_sigma,
+            absolute_sigma=absolute_sigma,
             # wavelength
             key_lamb=key_lamb,
             # optional 2d fit

--- a/spectrally/_class02_check_fit.py
+++ b/spectrally/_class02_check_fit.py
@@ -45,6 +45,7 @@ def _check(
     # data and noise
     key_data=None,
     key_sigma=None,
+    absolute_sigma=None,
     # wavelength and phi
     key_lamb=None,
     key_bs_vect=None,
@@ -68,6 +69,7 @@ def _check(
         key_lamb,
         key_bs_vect,
         key_bs,
+        absolute_sigma,
         # derived
         ref,
         ref0,
@@ -162,6 +164,7 @@ def _check(
                 'key_bs_vect': key_bs_vect,
                 'key_sol': None,
                 'key_cov': None,
+                'absolute_sigma': absolute_sigma,
                 'dparams': dparams,
                 'dvalid': dvalid,
             },
@@ -189,6 +192,7 @@ def _check_keys(
     key_lamb=None,
     key_bs_vect=None,
     key_bs=None,
+    absolute_sigma=None,
     # unused
     **kwdargs,
 ):
@@ -253,6 +257,51 @@ def _check_keys(
     # axis_lamb
     ref_lamb = coll.ddata[key_lamb]['ref'][0]
     axis_lamb = ref.index(ref_lamb)
+
+    # -------------
+    # key_sigma
+    # -------------
+
+    # key_sigma
+    if key_sigma is None or isinstance(key_sigma, str):
+
+        lok_data = [
+            k0 for k0, v0 in coll.ddata.items()
+            if v0['ref'] == ref
+            or v0['ref'] == ref_lamb
+        ]
+
+        lok = list(coll.ddata.keys())
+        key_sigma = ds._generic_check._check_var(
+            key_sigma, 'key_sigma',
+            types=str,
+            allowed=lok_data + ['poisson'],
+            default='poisson',
+        )
+
+        asig_def = True
+
+    else:
+        if not isinstance(key_sigma, (int, float)):
+            msg = (
+                "Arg key_sigma must either be:\n"
+                "\t- str: a key to a array with same shape as data or lamb\n"
+                "\t- 'poisson': poisson statictics\n"
+                "\t- float: constant unique sigma for all\n"
+            )
+            raise Exception(msg)
+
+        asig_def = False
+
+    # -------------
+    # absolute_sigma
+    # -------------
+
+    absolute_sigma = ds._generic_check._check_var(
+        absolute_sigma, 'absolute_sigma',
+        types=bool,
+        default=asig_def,
+    )
 
     # -------------
     # key_bs
@@ -328,6 +377,7 @@ def _check_keys(
         key_lamb,
         key_bs_vect,
         key_bs,
+        absolute_sigma,
         # derived
         ref,
         ref0,

--- a/spectrally/_class02_check_fit.py
+++ b/spectrally/_class02_check_fit.py
@@ -294,7 +294,7 @@ def _check_keys(
                 types=str,
                 allowed=lok_data + ['poisson'],
                 default='poisson',
-                extra_msg=_err_key_sigma(key_sigma, returnas=True),
+                extra_msg=_err_key_sigma(key_sigma, lok=lok, returnas=True),
             )
 
             asig_def = True
@@ -316,6 +316,10 @@ def _check_keys(
         absolute_sigma, 'absolute_sigma',
         types=bool,
         default=asig_def,
+        extra_msg=(
+            "Determines whether the error 'key_sigma' should be "
+            "understood as a relative or absolute error bar"
+        ),
     )
 
     # -------------
@@ -403,19 +407,23 @@ def _check_keys(
     )
 
 
-def _err_key_sigma(key_sigma=None, returnas=False):
+def _err_key_sigma(key_sigma=None, lok=None, returnas=False):
 
     msg = (
-        "Arg key_sigma must either be:\n"
-        "\t- str: a key to a array with:"
-            "\t\t- same units as key_data"
+        "Arg 'key_sigma' must either be:\n"
+        "\t- str: a key to a array with:\n"
+            "\t\t- same units as key_data\n"
             "\t\t- same ref as key_data or key_lamb\n"
             "\t\t- only strictly positive values\n"
-            "\t\tAvailable:{lok}\n"
+    )
+    if lok is not None:
+        msg += f"\t\tAvailable:\n\t{lok}\n"
+
+    msg += (
         "\t- 'poisson': poisson statictics (sqrt(data))\n"
         "\t- float or int : constant unique sigma for all data points\n"
         "\t- str: a float with '%' (e.g.: '5.0%'), constant percentage error\n"
-        "Provided:\n\t{key_sigma}"
+        f"\nProvided:\n\t{key_sigma}"
     )
 
     if returnas is True:

--- a/spectrally/_class02_check_fit.py
+++ b/spectrally/_class02_check_fit.py
@@ -18,20 +18,6 @@ from . import _class01_valid as _valid
 
 #############################################
 #############################################
-#       DEFAULTS
-#############################################
-
-
-_LFIT_ORDER = [
-    'sol',
-    'model', 'data', 'sigma', 'lamb', 'bs',
-    'positive', 'nsigma', 'fraction',
-    'mask', 'domain', 'focus',
-]
-
-
-#############################################
-#############################################
 #       fit CHECK
 #############################################
 
@@ -430,82 +416,6 @@ def _err_key_sigma(key_sigma=None, lok=None, returnas=False):
         return msg
     else:
         raise Exception(msg)
-
-
-#############################################
-#############################################
-#       Show
-#############################################
-
-
-def _show(coll=None, which=None, lcol=None, lar=None, show=None):
-
-    # ---------------------------
-    # column names
-    # ---------------------------
-
-    lcol.append([which] + _LFIT_ORDER)
-
-    # ---------------------------
-    # data
-    # ---------------------------
-
-    lkey = [
-        k1 for k1 in coll._dobj.get(which, {}).keys()
-        if show is None or k1 in show
-    ]
-
-    lar0 = []
-    for k0 in lkey:
-
-        # initialize with key
-        arr = [k0]
-
-        # add nb of func of each type
-        dfit = coll.dobj[which][k0]
-        for k1 in _LFIT_ORDER:
-
-            if k1 in ['model', 'data', 'sigma', 'lamb', 'bs', 'sol']:
-                nn = '' if dfit[f"key_{k1}"] is None else dfit[f"key_{k1}"]
-
-            elif k1 in ['nsigma', 'fraction', 'positive']:
-                nn = str(dfit['dvalid'][k1])
-
-            elif k1 in ['mask']:
-                nn = str(dfit['dvalid']['mask']['key'] is not None)
-
-            elif k1 in ['domain']:
-                c0 = all([
-                    len(v0['spec']) == 1
-                    and np.allclose(v0['spec'][0], np.inf*np.r_[-1, 1])
-                    for k0, v0 in dfit['dvalid']['domain'].items()
-                ])
-                if c0:
-                    nn = ''
-                else:
-                    lk = list(dfit['dvalid']['domain'].keys())
-                    if len(lk) == 2 and lk[0] != dfit['key_lamb']:
-                        lk = [lk[1], lk[0]]
-
-                    nn = ', '.join([
-                        str(len(dfit['dvalid']['domain'][k0]['spec']))
-                        for k0 in lk
-                    ])
-
-            elif k1 in ['focus']:
-                if dfit['dvalid'].get('focus') is None:
-                    nn = ''
-                else:
-                    nn = len(dfit['dvalid']['focus'])
-                    nn = f"{nn} / {dfit['dvalid']['focus_logic']}"
-
-            arr.append(nn)
-
-        lar0.append(arr)
-
-    lar.append(lar0)
-
-    return lcol, lar
 
 
 # ###########################################

--- a/spectrally/_class02_compute_fit.py
+++ b/spectrally/_class02_compute_fit.py
@@ -66,8 +66,10 @@ def main(
         key_model,
         key_data, key_lamb,
         ref_data, ref_lamb,
+        key_sigma,
         ref_cov, shape_cov,
-        lamb, data, axis,
+        lamb, data, sigma, axis,
+        absolute_sigma,
         chain,
         store, overwrite,
         strict, verb, verb_scp, timing,
@@ -145,6 +147,7 @@ def main(
         # lamb, data, axis
         lamb=lamb,
         data=data,
+        sigma=sigma,
         axis=axis,
         ravel=ravel,
         # binning
@@ -158,6 +161,7 @@ def main(
         # solver options
         solver=solver,
         dsolver_options=dsolver_options,
+        absolute_sigma=absolute_sigma,
         # options
         strict=strict,
         verb=verb,
@@ -265,6 +269,8 @@ def _check(
     key_model = coll.dobj[wsf][key]['key_model']
     key_data = coll.dobj[wsf][key]['key_data']
     key_lamb = coll.dobj[wsf][key]['key_lamb']
+    key_sigma = coll.dobj[wsf][key]['key_sigma']
+    absolute_sigma = coll.dobj[wsf][key]['absolute_sigma']
     lamb = coll.ddata[key_lamb]['data']
     data = coll.ddata[key_data]['data']
     ref_data = coll.ddata[key_data]['ref']
@@ -311,6 +317,19 @@ def _check(
             "Consider using another spectral model with pvoigt instead"
         )
         raise Exception(msg)
+
+    # ---------------
+    # sigma
+    # ---------------
+
+    if key_sigma == 'poisson':
+        sigma = None
+
+    elif isinstance(key_sigma, (int, float)):
+        sigma = None
+
+    else:
+        sigma = None
 
     # --------------
     # chain
@@ -394,8 +413,10 @@ def _check(
         key_model,
         key_data, key_lamb,
         ref_data, ref_lamb,
+        key_sigma,
         ref_cov, shape_cov,
-        lamb, data, axis,
+        lamb, data, sigma, axis,
+        absolute_sigma,
         chain,
         store, overwrite,
         strict, verb, verb_scp, timing,

--- a/spectrally/_class02_compute_fit_1d.py
+++ b/spectrally/_class02_compute_fit_1d.py
@@ -189,6 +189,7 @@ def main(
         # lamb, data, axis
         lamb=lamb,
         data=data,
+        sigma=sigma,
         axis=axis,
         # covarance
         ref_cov=ref_cov,
@@ -277,6 +278,7 @@ def _loop(
     # lamb, data, axis
     lamb=None,
     data=None,
+    sigma=None,
     axis=None,
     # covarance
     ref_cov=None,
@@ -415,7 +417,6 @@ def _loop(
     else:
         pass
 
-
     # -----------------
     # main loop
     # -----------------
@@ -535,7 +536,7 @@ def _loop(
                     lamb if dbinning is False else dbinning['lamb'],
                     data[slii][iok_all[slii]],
                     p0=x0,
-                    sigma=None,
+                    sigma=sigma[slii][iok_all[slii]],
                     absolute_sigma=absolute_sigma,
                     check_finite=True,    # to be updated
                     bounds=(bounds0, bounds1),

--- a/spectrally/_class02_compute_fit_1d.py
+++ b/spectrally/_class02_compute_fit_1d.py
@@ -3,7 +3,6 @@
 
 
 import itertools as itt
-import functools
 import datetime as dtm
 
 
@@ -40,6 +39,7 @@ def main(
     # lamb, data, axis
     lamb=None,
     data=None,
+    sigma=None,
     axis=None,
     ravel=None,
     # binning
@@ -53,6 +53,7 @@ def main(
     # solver options
     solver=None,
     dsolver_options=None,
+    absolute_sigma=None,
     # options
     strict=None,
     verb=None,
@@ -211,6 +212,7 @@ def main(
         # solver options
         solver=solver,
         dsolver_options=dsolver_options,
+        absolute_sigma=absolute_sigma,
         # options
         lk_xfree=lk_xfree,
         strict=strict,
@@ -298,6 +300,7 @@ def _loop(
     # solver options
     solver=None,
     dsolver_options=None,
+    absolute_sigma=None,
     # options
     lk_xfree=None,
     strict=None,
@@ -533,7 +536,7 @@ def _loop(
                     data[slii][iok_all[slii]],
                     p0=x0,
                     sigma=None,
-                    absolute_sigma=False,
+                    absolute_sigma=absolute_sigma,
                     check_finite=True,    # to be updated
                     bounds=(bounds0, bounds1),
                     jac=func_jac2,

--- a/spectrally/_class02_show.py
+++ b/spectrally/_class02_show.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Wed Jul 24 09:36:24 2024
+
+@author: dvezinet
+"""
+
+
+# common
+import numpy as np
+
+
+#############################################
+#############################################
+#       DEFAULTS
+#############################################
+
+
+_LFIT_ORDER = [
+    'sol',
+    'model', 'data', 'sigma', 'lamb', 'bs',
+    'positive', 'nsigma', 'fraction',
+    'mask', 'domain', 'focus',
+]
+
+
+#############################################
+#############################################
+#       Show
+#############################################
+
+
+def _show(coll=None, which=None, lcol=None, lar=None, show=None):
+
+    # ---------------------------
+    # column names
+    # ---------------------------
+
+    lcol.append([which] + _LFIT_ORDER)
+
+    # ---------------------------
+    # data
+    # ---------------------------
+
+    lkey = [
+        k1 for k1 in coll._dobj.get(which, {}).keys()
+        if show is None or k1 in show
+    ]
+
+    lar0 = []
+    for k0 in lkey:
+
+        # initialize with key
+        arr = [k0]
+
+        # add nb of func of each type
+        dfit = coll.dobj[which][k0]
+        for k1 in _LFIT_ORDER:
+
+            if k1 in ['model', 'data', 'sigma', 'lamb', 'bs', 'sol']:
+                nn = '' if dfit[f"key_{k1}"] is None else str(dfit[f"key_{k1}"])
+
+            elif k1 in ['nsigma', 'fraction', 'positive']:
+                nn = str(dfit['dvalid'][k1])
+
+            elif k1 in ['mask']:
+                nn = str(dfit['dvalid']['mask']['key'] is not None)
+
+            elif k1 in ['domain']:
+                c0 = all([
+                    len(v0['spec']) == 1
+                    and np.allclose(v0['spec'][0], np.inf*np.r_[-1, 1])
+                    for k0, v0 in dfit['dvalid']['domain'].items()
+                ])
+                if c0:
+                    nn = ''
+                else:
+                    lk = list(dfit['dvalid']['domain'].keys())
+                    if len(lk) == 2 and lk[0] != dfit['key_lamb']:
+                        lk = [lk[1], lk[0]]
+
+                    nn = ', '.join([
+                        str(len(dfit['dvalid']['domain'][k0]['spec']))
+                        for k0 in lk
+                    ])
+
+            elif k1 in ['focus']:
+                if dfit['dvalid'].get('focus') is None:
+                    nn = ''
+                else:
+                    nn = len(dfit['dvalid']['focus'])
+                    nn = f"{nn} / {dfit['dvalid']['focus_logic']}"
+
+            arr.append(nn)
+
+        lar0.append(arr)
+
+    lar.append(lar0)
+
+    return lcol, lar

--- a/spectrally/tutorials/tutorial.py
+++ b/spectrally/tutorials/tutorial.py
@@ -527,6 +527,7 @@ def _add_spectral_fit(coll=None, data=None):
             key_model='sm0',
             key_data='spectra',
             key_lamb='lamb',
+            key_sigma='poisson',
             dvalid={
                 'nsigma': 3,
                 'fraction': 0.31,
@@ -539,6 +540,7 @@ def _add_spectral_fit(coll=None, data=None):
             key_model='sm1',
             key_data='spectra',
             key_lamb='lamb',
+            key_sigma='5%',
             dvalid={
                 'nsigma': 3,
                 'fraction': 0.31,
@@ -551,6 +553,7 @@ def _add_spectral_fit(coll=None, data=None):
             key_model='sm1',
             key_data='spectra',
             key_lamb='lamb',
+            key_sigma=5,
             dvalid={
                 'nsigma': 3,
                 'fraction': 0.31,
@@ -568,7 +571,7 @@ def _add_spectral_fit(coll=None, data=None):
                 key=k0.replace('sm_', 'sf_'),
                 key_model=k0,
                 key_data='current',
-                key_sigma=None,
+                key_sigma='poisson',
                 key_lamb='sample',
                 # params
                 dvalid={
@@ -588,8 +591,50 @@ def _add_spectral_fit(coll=None, data=None):
                 key='sf0',
                 key_model=k0,
                 key_data='spectra',
-                key_sigma=None,
+                key_sigma='poisson',
                 key_lamb='lamb',
+                # params
+                dvalid={
+                    'nsigma': 2,
+                    'fraction': 0.11,
+                },
+            )
+
+            coll.add_spectral_fit(
+                key='sf1',
+                key_model=k0,
+                key_data='spectra',
+                key_sigma='poisson',
+                key_lamb='lamb',
+                absolute_sigma=False,
+                # params
+                dvalid={
+                    'nsigma': 2,
+                    'fraction': 0.11,
+                },
+            )
+
+            coll.add_spectral_fit(
+                key='sf2',
+                key_model=k0,
+                key_data='spectra',
+                key_sigma='10%',
+                key_lamb='lamb',
+                absolute_sigma=False,
+                # params
+                dvalid={
+                    'nsigma': 2,
+                    'fraction': 0.11,
+                },
+            )
+
+            coll.add_spectral_fit(
+                key='sf3',
+                key_model=k0,
+                key_data='spectra',
+                key_sigma=10,
+                key_lamb='lamb',
+                absolute_sigma=False,
                 # params
                 dvalid={
                     'nsigma': 2,


### PR DESCRIPTION
Main changes:
-----------------

* `add_spectral_fit(key_sigma=..., absolute_sigma=bool)` implemented
    - `'key_sigma'` must be:
        - `str`: a key to an existing data array with:
               - same units as `'key_data'`
               - same ref as `'key_data'` or `'key_lamb'`
               - only strictly positive values
        - `'poisson'`: poisson statictics (sqrt(data), Default)
        - `float` or `int` : constant unique sigma for all data points"
        - `str`: a `float` with '%' (e.g.: '5.0%'), constant percentage error
    - `absolute_sigma`: flag indicating whether the `sigma` should be understood as absolute or relative only (default: True)
        - this can have an impact on the covariance matrix
* `compute_spectral_fit(solver='scipy.curve_fit')` now properly handles `sigma` and computes covariance matrix accordingly
* `interpolate_spectral_model()` now properly handles the covariance matrix returned by `compute_spectral_fit()` and uses it to compute the error bar on the total fit function (`dout['data_min']` and `dout['data_max']`)

Caveat: uncertainty propagation is now properly done to the fit function only, it is not yet properly propagated to the moments (`'Ti'`, `'argmax'`, etc...)


* `show('spectral_fit')` more informative
* Added unit tests for `python 3.11`

Issues:
-------

Fixes, in devel, issue #76 


Examples:
-----------

The tutorial, using `data='ebit'` now computes the same fit with 4 different assumptions on `sigma` (`absolute_sigma`).

Below is a comparison of the 4 resulting uncertainties for the last time step:

```
import spectrally as sp

# run tutorial
coll, dax, dout = sp.tutorials.main(data='ebit', chain=False, binning=False)

# extract interpolated solutions
dout = coll.interpolate_spectral_model(key_model='sf0', store=False, uncertainty_method='standard')
dout2 = coll.interpolate_spectral_model(key_model='sf1', store=False, uncertainty_method='standard')
dout3 = coll.interpolate_spectral_model(key_model='sf2', store=False, uncertainty_method='standard')
dout4 = coll.interpolate_spectral_model(key_model='sf3', store=False, uncertainty_method='standard')

# prepare figure
fig = plt.figure()
ax = fig.add_axes([0.1, 0.1, 0.8, 0.8])

# input data
ax.plot(dout['lamb'], coll.ddata['spectra']['data'][-1, ...], '.-k')

# default: Poisson noise + absolute sigma
ax.plot(dout['lamb'], dout['data'][-1, ...], '.-k')
ax.fill_between(dout['lamb'], dout['data_min'][-1, ...], dout['data_max'][-1, ...], fc=(0.8, 0.8, 0.8, 0.5), label='poisson (abs)')

# Poisson noise + relative sigma
ax.plot(dout2['lamb'], dout2['data'][-1, ...], '.-r')
ax.fill_between(dout2['lamb'], dout2['data_min'][-1, ...], dout2['data_max'][-1, ...], fc=(0.8, 0., 0., 0.3), label='poisson (rel)')

# constant noise + absolute sigma
ax.plot(dout3['lamb'], dout3['data'][-1, ...], '.-b')
ax.fill_between(dout3['lamb'], dout3['data_min'][-1, ...], dout3['data_max'][-1, ...], fc=(0., 0., 0.8, 0.3), label='10\% (abs)')

# constant relative noise + absolute sigma
ax.plot(dout4['lamb'], dout4['data'][-1, ...], '.-g')
ax.fill_between(dout4['lamb'], dout4['data_min'][-1, ...], dout4['data_max'][-1, ...], fc=(0., 0.8, 0., 0.3), label='10 (abs)')

# decorate
ax.set_xlabel('lamb (m)', size=12, fontweight='bold')
ax.set_ylabel('data (counts)', size=12, fontweight='bold')
ax.legend()
```

![image](https://github.com/user-attachments/assets/f70e9b63-6e9a-4897-83ac-fb810c4ee8b7)